### PR TITLE
use circle to close side menu without losing filters

### DIFF
--- a/source/pkgi.c
+++ b/source/pkgi.c
@@ -550,7 +550,7 @@ static void pkgi_do_tail(void)
 
     if (pkgi_menu_is_open())
     {
-        pkgi_snprintf(text, sizeof(text), "%s Select  " PKGI_UTF8_T " Close  %s Cancel", pkgi_get_ok_str(), pkgi_get_cancel_str());
+        pkgi_snprintf(text, sizeof(text), "%s Select  %s Close", pkgi_get_ok_str(), pkgi_get_cancel_str());
     }
     else
     {

--- a/source/pkgi_menu.c
+++ b/source/pkgi_menu.c
@@ -158,12 +158,6 @@ int pkgi_do_menu(pkgi_input* input)
 
     if (input->pressed & pkgi_cancel_button())
     {
-        menu_result = MenuResultCancel;
-        menu_delta = -1;
-        return 1;
-    }
-    else if (input->pressed & PKGI_BUTTON_T)
-    {
         menu_result = MenuResultAccept;
         menu_delta = -1;
         return 1;


### PR DESCRIPTION
As discussed here: https://github.com/bucanero/pkgi-ps3/issues/43 this is to change the default triangle to save and exit the menu and circle to cancel and exit the menu to just circle, which saves the filter.

The reasoning is that circle is almost always used to go back, close some sort of menu on PlayStation platforms. Many times I pressed circle to exit losing my changes.

